### PR TITLE
change connection options to tolerate slow requests

### DIFF
--- a/R/ConnectToCCP.R
+++ b/R/ConnectToCCP.R
@@ -27,11 +27,6 @@ ConnectToCCP <- function(ServerSpecifications,
   httr::set_config(httr::use_proxy(url = proxyurl, port = 8062))
   httr::set_config(httr::config(ssl_verifyhost = 0L, ssl_verifypeer = 0L))
 
-  # Opal settings form Client-side
-  options(opal.opts = httr::config(timeout = 1800),
-          opal.retry.times = 5,
-          opal.retry.quiet = FALSE)
-
   # Create an environment
   LoginBuilder <- DSI::newDSLoginBuilder(.silent = FALSE)
 
@@ -46,10 +41,11 @@ ConnectToCCP <- function(ServerSpecifications,
   # Returns a data frame of login data to CCP Sites
   LoginData <- LoginBuilder$build()
 
+  opts <- list(ssl_verifypeer = FALSE, low_speed_time = 0, low_speed_limit = 0)
   # Perform login process and get list of DSConnection objects of all servers
   CCPConnections <- DSI::datashield.login(logins = LoginData,
                                           assign = TRUE,
-                                          opts = list(ssl_verifypeer = FALSE),
+                                          opts = opts,
                                           failSafe = TRUE)
 
 #--- Return DSConnection objects -----------------------------------------------

--- a/R/ConnectToVirtualCCP.R
+++ b/R/ConnectToVirtualCCP.R
@@ -180,14 +180,10 @@ ConnectToVirtualCCP <- function(CCPData,
   # Returns a data.frame of login data
   LoginData <- LoginBuilder$build()
 
-  # Set the timeout to 30 minutes (1800 seconds)
-  options(opal.opts = httr::config(timeout = 1800),
-          opal.retry.times = 5,
-          opal.retry.quiet = FALSE)
-
   # Get list of DSConnection objects of all servers
   CCPConnections <- DSI::datashield.login(logins = LoginData,
-                                          assign = TRUE)
+                                          assign = TRUE,
+                                          opts = list(low_speed_time = 0, low_speed_limit = 0))
 
 #-------------------------------------------------------------------------------
   return(CCPConnections)


### PR DESCRIPTION
This removes the previous attempt at increasing the timeout and fixes the underlying issue by setting the httr options `low_speed_time` and `low_speed_limit` which were the root cause of the 10m timeout.

By default httr/libcurl don't set a regular request timeout but there is a default of 600s for the `low_speed_time` which caused the connection to retry the connection.